### PR TITLE
Moving back the js package name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,5 +28,5 @@ jobs:
         jlpm
         python -m pip install .
 
-        jupyter labextension list 2>&1 | grep -ie "jupyter_jaeger.*OK"
+        jupyter labextension list 2>&1 | grep -ie "jupyter-jaeger.*OK"
         # python -m jupyterlab.browser_check

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 include LICENSE
 include README.md
 include pyproject.toml
-include jupyter-config/jupyter_jaeger.json
+include jupyter-config/jupyter-jaeger.json
 
 include package.json
 include install.json

--- a/install.json
+++ b/install.json
@@ -1,5 +1,5 @@
 {
   "packageManager": "python",
-  "packageName": "jupyter_jaeger",
+  "packageName": "jupyter-jaeger",
   "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package jupyter-jaeger"
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jupyter_jaeger",
+  "name": "jupyter-jaeger",
   "version": "1.0.4",
   "description": "A library for saving traces to jaeger",
   "keywords": [

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ import setuptools
 HERE = os.path.abspath(os.path.dirname(__file__))
 
 # The name of the project
-name="jupyter_jaeger"
+name = "jupyter_jaeger"
 
 # Get our version
 with open(os.path.join(HERE, 'package.json')) as f:
@@ -32,7 +32,7 @@ package_data_spec = {
     ]
 }
 
-labext_name = "jupyter_jaeger"
+labext_name = "jupyter-jaeger"
 
 data_files_spec = [
     ("share/jupyter/labextensions/%s" % labext_name, lab_path, "**"),


### PR DESCRIPTION
This PR moves back the original name for jupyter jaeger (with dash instead of underscore)