### PR TITLE
Add release workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+
+
+.PHONY: release-npmjs
+release-js:
+	npm login
+	npm publish
+
+
+.PHONY: release-pypi
+release-pypi:
+	rm -f dist/*
+	python setup.py sdist
+	twine upload dist/*

--- a/README.md
+++ b/README.md
@@ -98,3 +98,29 @@ in [`./example`](./example). You can try this example by:
 2. Create a launcher and launch the Jaeger UI
 3. Run the notebook.
 4. Inspect the trace created by the notebook execution.
+
+
+## Releasing
+
+For releasing, you will need a specific conda environment:
+
+```sh
+conda env create --file environment-release.yaml
+conda activate jupyter-jaeger-release
+```
+
+Now, you can use `make` to publish for **npmjs** and **pypi**.
+
+```sh
+# to publish to npmjs
+make release-npmjs
+# to publish to pypi
+make release-pypi
+```
+
+Also, create a git tag for the new release, for example:
+
+```sh
+git tag 1.0.4
+git push --tags
+```

--- a/environment-release.yaml
+++ b/environment-release.yaml
@@ -1,0 +1,11 @@
+name: jupyter-jaeger-release
+channels:
+  - conda-forge
+dependencies:
+  - jupyter-packaging 0.7.9
+  - make
+  - nodejs
+  - python 3.8.*
+  - setuptools>=40.8.0
+  - twine
+  - wheel


### PR DESCRIPTION
This PR 

- adds a make targets for pypi and npmjs publishing
- adds a conda environment for releasing
- adds information to readme about how to release a new version